### PR TITLE
Feature/persist volume

### DIFF
--- a/src/app/components/volume/volume.component.ts
+++ b/src/app/components/volume/volume.component.ts
@@ -4,8 +4,7 @@ import { MatIconButton } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatSlider, MatSliderThumb } from '@angular/material/slider';
-import { Subscription, map } from 'rxjs';
-import { PlayerService, PlayerState } from 'src/app/services/player.service';
+import { PlayerService } from 'src/app/services/player.service';
 
 @Component({
   selector: 'app-volume',
@@ -27,32 +26,22 @@ export class VolumeComponent {
   step = 0.01;
 
   // number from 0 to 1
-  _current: number = 1;
   muted: boolean;
 
   private lastValue: number;
 
   get current(): number {
-    return this._current
+    return this.playerService.volume
   }
 
   set current(val: number) {
-    this._current = val
     this.muted = false
     this.playerService.setVolume(val)
   }
 
-  private subscriptions: Subscription[] = []
-
   constructor(
     private playerService: PlayerService,
-  ) {
-    this.subscriptions.push(
-      playerService.state$.pipe(map((state: PlayerState) => {
-        this._current = state.volume
-      })).subscribe()
-    )
-  }
+  ) { }
 
   toggleMute() {
     if (this.muted) {

--- a/src/app/services/player.service.ts
+++ b/src/app/services/player.service.ts
@@ -31,6 +31,7 @@ export class PlayerService implements OnDestroy {
   private _playerLoaded: boolean;
   private _apiUrl: string;
 
+  volume: number = 1;
   shuffle: boolean;
   globalLoop: Loop = {
     loopType: "default"
@@ -156,6 +157,8 @@ export class PlayerService implements OnDestroy {
       }
     }
 
+    // set volume as current set
+    opts.volume = this.volume || 1;
     this._player.play(url, opts as Options);
     this._playingSubj.next(song)
     this.saveState()
@@ -173,6 +176,8 @@ export class PlayerService implements OnDestroy {
   }
 
   setVolume(level: number) {
+    this.volume = level
+
     if (!this._playerLoaded) return
     this._player.setVolume(level);
   }

--- a/src/app/services/player.service.ts
+++ b/src/app/services/player.service.ts
@@ -17,6 +17,7 @@ const storagePlayerKey = "player"
 type storageObject = {
   playlist: Song[],
   player: {
+    volume: number,
     currentSong: Song,
     currentIndex: number,
     currentLoop: Loop
@@ -82,10 +83,11 @@ export class PlayerService implements OnDestroy {
     )
   }
 
-  private saveState() {
+  private async saveState() {
     this.storage.set(storagePlayerKey, {
       playlist: this._playlist,
       player: {
+        volume: this.volume,
         currentSong: this._playlist[this.currentIndex],
         currentIndex: this.currentIndex,
         currentLoop: this.globalLoop
@@ -103,6 +105,7 @@ export class PlayerService implements OnDestroy {
           this._playingSubj.next(cache.player.currentSong)
         }
         this.globalLoop = cache.player.currentLoop
+        this.volume = cache.player.volume
       }
     })
   }
@@ -177,6 +180,7 @@ export class PlayerService implements OnDestroy {
 
   setVolume(level: number) {
     this.volume = level
+    this.saveState()
 
     if (!this._playerLoaded) return
     this._player.setVolume(level);


### PR DESCRIPTION
Volume was being reset to 100% on song changes, which is not good for your ears! Instead let us pass the current volume to SCM player options so it remembers the set volume instead.

And since this is another user set state, persist in localStorage.