### PR TITLE
set z-index higher

### DIFF
--- a/src/app/components/player/player.component.scss
+++ b/src/app/components/player/player.component.scss
@@ -37,7 +37,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 99;
+  z-index: 1001;
   margin: auto;
   display: block;
   position: fixed;


### PR DESCRIPTION
Make the small player a bit higher, so it is also on top of dialog backdrops. This lets users control the small player when they have an open song details modal open.