### PR TITLE
Style/ Bigger progress bar width on small player

### DIFF
--- a/src/app/components/player/player.component.html
+++ b/src/app/components/player/player.component.html
@@ -77,7 +77,10 @@
   </ng-template>
 
   <ng-template #trackInfo>
-    <span class="track-info" *ngIf="playing">
-      {{ playing.name }} ({{ playing.uploader }}) · <span class="game-name">{{ playing.game_name }}</span>
+    <span class="track-info" *ngIf="playing" [matTooltip]="'Uploaded by: ' + playing.uploader">
+      <p>
+        {{ playing.name }}
+      </p>
+      <p class="game-name">{{ playing.game_name }}</p>
     </span>
   </ng-template>

--- a/src/app/components/player/player.component.html
+++ b/src/app/components/player/player.component.html
@@ -64,7 +64,7 @@
       <span class="time time-elapsed">{{ timeElapsed | date : "mm:ss" }}</span>
       <div class="progress-bar">
         @if (this.buffering$ | async) {
-        <mat-progress-bar mode="indeterminate" style="width: 120px"></mat-progress-bar>
+        <mat-progress-bar mode="indeterminate"></mat-progress-bar>
         } @else {
         <mat-slider>
           <input matSliderThumb [value]="percElapsed()" (click)="seek(elapsedSlider.value)" #elapsedSlider>

--- a/src/app/components/player/player.component.scss
+++ b/src/app/components/player/player.component.scss
@@ -98,6 +98,10 @@
   .track-info {
     margin-left: 35px;
     flex: 4;
+
+    p {
+      margin: auto 0;
+    }
   }
 }
 

--- a/src/app/components/player/player.component.scss
+++ b/src/app/components/player/player.component.scss
@@ -69,7 +69,8 @@
     text-wrap: nowrap;
     width: 100%;
 
-    .mat-mdc-slider {
+    .mat-mdc-slider,
+    .mat-mdc-progress-bar {
       width: 100%;
       margin: 0 auto;
     }

--- a/src/app/components/player/player.component.scss
+++ b/src/app/components/player/player.component.scss
@@ -61,11 +61,18 @@
   max-width: 100%;
   display: flex;
   align-items: center;
+  flex: 3;
 
   .progress-bar {
     flex-shrink: 1;
     display: inline-block;
     text-wrap: nowrap;
+    width: 100%;
+
+    .mat-mdc-slider {
+      width: 100%;
+      margin: 0 auto;
+    }
   }
 
   .time {
@@ -90,6 +97,7 @@
 
   .track-info {
     margin-left: 35px;
+    flex: 4;
   }
 }
 

--- a/src/app/components/player/player.component.ts
+++ b/src/app/components/player/player.component.ts
@@ -9,6 +9,7 @@ import { MatProgressBar } from '@angular/material/progress-bar';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatSlider, MatSliderThumb } from '@angular/material/slider';
 import { MatCell, MatCellDef, MatColumnDef, MatRow, MatRowDef, MatTable } from '@angular/material/table';
+import { MatTooltip } from '@angular/material/tooltip';
 import { Observable, Subscription } from 'rxjs';
 import { Loop, Song } from '../../models/scm.model';
 import { PlayerService } from '../../services/player.service';
@@ -42,6 +43,7 @@ import { VolumeComponent } from '../volume/volume.component';
     MatDivider,
     MatProgressSpinner,
     MatProgressBar,
+    MatTooltip,
     DatePipe,
     PlaylistComponent,
     LoopSelectorComponent,


### PR DESCRIPTION
Makes the progress bar bigger to occupy a bigger horizontal space on screen and to be a proportion of the view size (resizing browser adjusts size).

Also tweaks the song name to be on two rows instead of just a single line and puts uploader as a tooltip when hovering the song name.